### PR TITLE
Replace active_support and active_support/core_ext requires with active_support/all

### DIFF
--- a/lib/airbrake.rb
+++ b/lib/airbrake.rb
@@ -2,13 +2,7 @@ require "girl_friday"
 require 'net/http'
 require 'net/https'
 require 'rubygems'
-begin
-  require 'active_support'
-  require 'active_support/core_ext'
-rescue LoadError
-  require 'activesupport'
-  require 'activesupport/core_ext'
-end
+require 'active_support/all'
 require 'airbrake/version'
 require 'airbrake/configuration'
 require 'airbrake/notice'


### PR DESCRIPTION
We've been hitting this error after bumping the activesupport gem in our project:

```
2014-03-05_22:02:24.60840 uninitialized constant ActiveSupport::Deprecation::MethodWrapper
2014-03-05_22:02:24.60850 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/deprecation.rb:26:in `<class:Deprecation>'
2014-03-05_22:02:24.60852 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/deprecation.rb:6:in `<module:ActiveSupport>'
2014-03-05_22:02:24.60852 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/deprecation.rb:3:in `<top (required)>'
2014-03-05_22:02:24.60853 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/deprecation/method_wrappers.rb:5:in `<module:ActiveSupport>'
2014-03-05_22:02:24.60854 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/deprecation/method_wrappers.rb:4:in `<top (required)>'
2014-03-05_22:02:24.60855 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext/module/deprecation.rb:1:in `require'
2014-03-05_22:02:24.60855 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext/module/deprecation.rb:1:in `<top (required)>'
2014-03-05_22:02:24.60857 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext/module.rb:8:in `require'
2014-03-05_22:02:24.60858 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext/module.rb:8:in `<top (required)>'
2014-03-05_22:02:24.60859 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext.rb:3:in `require'
2014-03-05_22:02:24.60860 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext.rb:3:in `block in <top (required)>'
2014-03-05_22:02:24.60860 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext.rb:1:in `each'
2014-03-05_22:02:24.60863 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/activesupport-4.0.3/lib/active_support/core_ext.rb:1:in `<top (required)>'
2014-03-05_22:02:24.60863 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/bundler/gems/airbrake-3477a397ea01/lib/airbrake.rb:7:in `require'
2014-03-05_22:02:24.60864 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/bundler/gems/airbrake-3477a397ea01/lib/airbrake.rb:7:in `<top (required)>'
2014-03-05_22:02:24.60866 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god/contacts/airbrake.rb:7:in `require'
2014-03-05_22:02:24.60868 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god/contacts/airbrake.rb:7:in `block in <top (required)>'
2014-03-05_22:02:24.60869 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god/contacts/airbrake.rb:6:in `each'
2014-03-05_22:02:24.60869 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god/contacts/airbrake.rb:6:in `<top (required)>'
2014-03-05_22:02:24.60870 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god.rb:80:in `require'
2014-03-05_22:02:24.60871 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god.rb:80:in `load_contact'
2014-03-05_22:02:24.60872 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/lib/god.rb:94:in `<top (required)>'
2014-03-05_22:02:24.60874 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/bin/god:119:in `require'
2014-03-05_22:02:24.60874 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/gems/god-0.13.3/bin/god:119:in `<top (required)>'
2014-03-05_22:02:24.60876 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/bin/god:23:in `load'
2014-03-05_22:02:24.60877 /u/apps/reports-reportify-etl/shared/bundle/ruby/2.1.0/bin/god:23:in `<main>'
```

And seems to be related to the ordering of some active support requires... So after some fumbling, @arthurnn and I have settled on this solution.

@wisq @arthurnn @mkobetic for review

/cc @Shopify/reports 
